### PR TITLE
Prediction service

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "git.ignoreLimitWarning": true,
     "python.defaultInterpreterPath": ".venv/bin/python",
-    "python.languageServer": "Default",
+    "python.languageServer": "None",
     "python.analysis.typeCheckingMode": "basic",
     "python.analysis.autoSearchPaths": true,
     "python.analysis.diagnosticMode": "workspace",
@@ -35,9 +35,6 @@
     "ruff.enable": true,
     "ruff.lint.enable": true,
     "ruff.format.enable": true,
-    "cursorpyright.analysis.autoSearchPaths": true,
-    "cursorpyright.analysis.diagnosticMode": "workspace",
-    "cursorpyright.analysis.typeCheckingMode": "basic",
     "yaml.schemas": {
         "kubernetes://schema/apps/v1%40deployment": "file:///workspaces/realtime-crypto-ml-system/deployments/dev/backfill-technical-indicators/backfill-technical-indicators.yaml"
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,10 @@
 {
     "git.ignoreLimitWarning": true,
-    "python.languageServer": "None",
-    "python.analysis.typeCheckingMode": "off",
-    "python.analysis.autoSearchPaths": false,
-    "python.analysis.diagnosticMode": "off",
+    "python.defaultInterpreterPath": ".venv/bin/python",
+    "python.languageServer": "Default",
+    "python.analysis.typeCheckingMode": "basic",
+    "python.analysis.autoSearchPaths": true,
+    "python.analysis.diagnosticMode": "workspace",
     "python.linting.enabled": true,
     "python.linting.ruffEnabled": true,
     "python.linting.mypyEnabled": false,
@@ -34,9 +35,9 @@
     "ruff.enable": true,
     "ruff.lint.enable": true,
     "ruff.format.enable": true,
-    "cursorpyright.analysis.autoSearchPaths": false,
-    "cursorpyright.analysis.diagnosticMode": "off",
-    "cursorpyright.analysis.typeCheckingMode": "off",
+    "cursorpyright.analysis.autoSearchPaths": true,
+    "cursorpyright.analysis.diagnosticMode": "workspace",
+    "cursorpyright.analysis.typeCheckingMode": "basic",
     "yaml.schemas": {
         "kubernetes://schema/apps/v1%40deployment": "file:///workspaces/realtime-crypto-ml-system/deployments/dev/backfill-technical-indicators/backfill-technical-indicators.yaml"
     },

--- a/deployments/dev/prediction-generator/kustomization.yaml
+++ b/deployments/dev/prediction-generator/kustomization.yaml
@@ -1,0 +1,13 @@
+#
+#  https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/
+#
+#  kustomize build deployments/dev/training-pipeline | kubectl apply -f -
+#
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: services
+resources:
+  - ./prediction-generator-dp.yaml
+  - ./prediction-generator-cm.yaml

--- a/deployments/dev/prediction-generator/prediction-generator-cm.yaml
+++ b/deployments/dev/prediction-generator/prediction-generator-cm.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prediction-generator-config
+  namespace: services
+data:
+  MLFLOW_TRACKING_URI: "http://mlflow-tracking.mlflow.svc.cluster.local:80"
+  MLFLOW_TRACKING_USERNAME: "user"
+  MLFLOW_TRACKING_PASSWORD: "6440921D-2493-42AA-BE40-428CD753D81D"
+  RISINGWAVE_HOST: "risingwave.risingwave.svc.cluster.local"
+  RISINGWAVE_PORT: "4567"
+  RISINGWAVE_USER: "root"
+  RISINGWAVE_PASSWORD: "123456"
+  RISINGWAVE_SCHEMA: "public"
+  RISINGWAVE_DATABASE: "dev"
+  RISINGWAVE_INPUT_TABLE: "technical_indicators"
+  RISINGWAVE_OUTPUT_TABLE: "predictions"
+  PAIR: "BTC/USD"
+  CANDLE_SECONDS: "60"
+  PREDICTION_HORIZON_SECONDS: "3600"
+  MODEL_ALIAS: "champion"

--- a/deployments/dev/prediction-generator/prediction-generator-dp.yaml
+++ b/deployments/dev/prediction-generator/prediction-generator-dp.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prediction-generator
+  namespace: services
+  labels:
+    app: prediction-generator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prediction-generator
+  template:
+    metadata:
+      labels:
+        app: prediction-generator
+    spec:
+      containers:
+      - name: prediction-generator
+        image: prediction-generator:dev
+        imagePullPolicy: Never # Use the local image
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        envFrom:
+        - configMapRef:
+            name: prediction-generator-config

--- a/deployments/dev/training-pipeline/training-pipeline-cj.yaml
+++ b/deployments/dev/training-pipeline/training-pipeline-cj.yaml
@@ -18,6 +18,7 @@ spec:
   schedule: "0 * * * *" # every hour
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 3600  # Kill job after 1 hour if stuck
       template:
         spec:
           restartPolicy: OnFailure
@@ -27,11 +28,11 @@ spec:
             imagePullPolicy: Never # Use the local image
             resources:
               requests:
-                cpu: "500m"
-                memory: "2Gi"
+                cpu: "1000m"      # Request 1 CPU core
+                memory: "4Gi"     # Request 4Gi memory
               limits:
-                cpu: "2000m"      # Max 2 CPU cores
-                memory: "6Gi"     # Increased from 2Gi to 6Gi
+                cpu: "4000m"      # Max 4 CPU cores for LazyRegressor
+                memory: "12Gi"    # Max 12Gi memory for multiple models
             env:
             #
             - name: MLFLOW_TRACKING_URI

--- a/docker/prediction-generator.Dockerfile
+++ b/docker/prediction-generator.Dockerfile
@@ -1,0 +1,36 @@
+# Training pipeline - predictor service with heavy ML dependencies
+FROM base:latest
+
+USER root
+
+# Install additional build tools for heavy ML packages
+RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
+    gcc \
+    g++ \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy workspace files for proper dependency resolution
+COPY pyproject.toml uv.lock ./
+COPY services/ ./services/
+
+# Install only predictor package dependencies using uv workspace (including training extras)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --package predictor --extra training && \
+    # Basic cleanup \
+    find .venv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \
+    find .venv -type f -name "*.pyc" -delete 2>/dev/null || true && \
+    echo "=== TRAINING-PIPELINE VENV SIZE ===" && du -sh .venv
+
+# Set timeout for heavy ML package downloads
+ENV UV_HTTP_TIMEOUT=300
+
+# Set ownership for app directory
+RUN chown -R appuser:appuser /app
+
+USER appuser
+
+WORKDIR /app/services/predictor
+
+CMD ["uv", "run", "--package", "predictor", "python", "/app/services/predictor/src/predictor/predict.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,8 @@ lint.ignore = [
 [tool.ruff.format]
 indent-style = "space"
 quote-style = "single"
+
+[dependency-groups]
+dev = [
+    "ruff>=0.12.1",
+]

--- a/services/predictor/pyproject.toml
+++ b/services/predictor/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "scikit-learn>=1.7.0",
     "optuna>=4.4.0",
     "pydantic-settings>=2.9.1",
+    "shap>=0.48.0",
+    "matplotlib>=3.10.0",
 ]
 
 [project.optional-dependencies]

--- a/services/predictor/pyproject.toml
+++ b/services/predictor/pyproject.toml
@@ -34,3 +34,8 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ruff>=0.12.1",
+]

--- a/services/predictor/query.sql
+++ b/services/predictor/query.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS {risingwave_output_table} (
+    pair VARCHAR,
+    ts_ms BIGINT,
+
+    -- useful for monitoring the model performance
+    model_name VARCHAR,
+    model_version INT,
+
+    predicted_ts_ms BIGINT,
+    predicted_price FLOAT,
+
+    PRIMARY KEY (pair, ts_ms, model_name, model_version, predicted_ts_ms)
+);

--- a/services/predictor/src/predictor/config.py
+++ b/services/predictor/src/predictor/config.py
@@ -79,7 +79,7 @@ class PredictorConfig(BaseSettings):
     pair: str = 'BTC/USD'
     candle_seconds: int = 60
     prediction_horizon_seconds: int = 3600  # 1 hour
-    model_version: str = 'latest'
+    model_alias: str = 'champion'
 
 
 predictor_config = PredictorConfig()

--- a/services/predictor/src/predictor/config.py
+++ b/services/predictor/src/predictor/config.py
@@ -2,6 +2,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class TrainingConfig(BaseSettings):
+    """
+    Configuration for the training pipeline
+    """
+
     model_config = SettingsConfigDict(
         env_file='services/predictor/settings.env', env_file_encoding='utf-8'
     )
@@ -52,3 +56,30 @@ class TrainingConfig(BaseSettings):
 
 
 training_config = TrainingConfig()
+
+
+class PredictorConfig(BaseSettings):
+    """
+    Configuration for the predictor
+    """
+
+    model_config = SettingsConfigDict(
+        env_file='services/predictor/settings.env', env_file_encoding='utf-8'
+    )
+    mlflow_tracking_uri: str = 'http://localhost:5000'
+    risingwave_host: str = 'localhost'
+    risingwave_port: int = 4567
+    risingwave_user: str = 'root'
+    risingwave_password: str = '123456'
+    risingwave_schema: str = 'public'
+    risingwave_database: str = 'dev'
+    risingwave_input_table: str = 'technical_indicators'
+    risingwave_output_table: str = 'predictions'
+
+    pair: str = 'BTC/USD'
+    candle_seconds: int = 60
+    prediction_horizon_seconds: int = 3600  # 1 hour
+    model_version: str = 'latest'
+
+
+predictor_config = PredictorConfig()

--- a/services/predictor/src/predictor/model_registry.py
+++ b/services/predictor/src/predictor/model_registry.py
@@ -1,7 +1,21 @@
+"""
+Model registry for the predictor service.
+
+This module provides functionality to load and push models to the MLflow model registry.
+
+Key Features:
+- Loading models from the MLflow model registry
+- Pushing models to the MLflow model registry
+- Inferring model signatures
+"""
+
+from typing import Optional
+
 import mlflow
 import pandas as pd
 from loguru import logger
-from mlflow.models.signature import infer_signature
+from mlflow.models import Model
+from mlflow.tracking import MlflowClient
 
 
 def get_model_name(
@@ -14,6 +28,29 @@ def get_model_name(
     """
     return f'{pair.replace("/", "-")}_{candle_seconds}s_{prediction_horizon_seconds}s'
 
+# TODO: Create a custom type to annotate the output of this function
+def load_model(
+    model_name: str,
+    model_version: Optional[str] = "latest",
+) -> tuple[Model, list[str], str]:
+    """
+    Load the model from the MLFlow model registry.
+    """
+    model = mlflow.sklearn.load_model(
+        model_uri=f'models:/{model_name}/{model_version}'
+    )
+
+    # Get the model info which contains the signature to extract the features.
+    model_info = mlflow.models.get_model_info(
+        model_uri=f'models:/{model_name}/{model_version}'
+    )
+
+    features = model_info.signature.inputs.input_names()
+
+    client = MlflowClient()
+    model_version = client.get_latest_versions(model_name, stages=['None'])[0].version
+
+    return model, features, model_version
 
 def push_model(
     model,
@@ -30,11 +67,11 @@ def push_model(
     """
     # Infer the model signature
     y_pred = model.predict(X_test)
-    signature = infer_signature(X_test, y_pred)
+    signature = mlflow.models.infer_signature(X_test, y_pred)
 
     # Log the sklearn model and register as version 1
     logger.info(f'Pushing model {model_name} to the model registry')
-    mlflow.sklearn.log_model(
+    mlflow.sklearn.log_model(  # type: ignore
         sk_model=model,
         name=model_name,
         signature=signature,

--- a/services/predictor/src/predictor/model_registry.py
+++ b/services/predictor/src/predictor/model_registry.py
@@ -9,14 +9,18 @@ Key Features:
 - Inferring model signatures
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 import mlflow
+import mlflow.exceptions
+import mlflow.models
+import mlflow.sklearn
 import pandas as pd
 from loguru import logger
-from mlflow.models import Model
+from mlflow.models import MetricThreshold, Model
 from mlflow.tracking import MlflowClient
 
+client = MlflowClient()
 
 def get_model_name(
     pair: str,
@@ -31,50 +35,158 @@ def get_model_name(
 # TODO: Create a custom type to annotate the output of this function
 def load_model(
     model_name: str,
-    model_version: Optional[str] = "latest",
+    model_alias: str = 'champion',
 ) -> tuple[Model, list[str], str]:
     """
     Load the model from the MLFlow model registry.
-    """
-    model = mlflow.sklearn.load_model(
-        model_uri=f'models:/{model_name}/{model_version}'
-    )
-
-    # Get the model info which contains the signature to extract the features.
-    model_info = mlflow.models.get_model_info(
-        model_uri=f'models:/{model_name}/{model_version}'
-    )
-
-    features = model_info.signature.inputs.input_names()
-
-    client = MlflowClient()
-    model_version = client.get_latest_versions(model_name, stages=['None'])[0].version
-
-    return model, features, model_version
-
-def push_model(
-    model,
-    X_test: pd.DataFrame,
-    model_name: str,
-) -> None:
-    """
-    Pushes the given `model` to the MLflow model registry using the given `model_name`.
 
     Args:
-        model: The model to push to the model registry.
-        X_test: The test data to use to infer the model signature.
-        model_name: The name of the model to push to the model registry.
-    """
-    # Infer the model signature
-    y_pred = model.predict(X_test)
-    signature = mlflow.models.infer_signature(X_test, y_pred)
+        model_name: Name of the model in the registry
+        model_alias: Alias to use (defaults to 'champion', falls back to 'latest')
 
-    # Log the sklearn model and register as version 1
-    logger.info(f'Pushing model {model_name} to the model registry')
-    mlflow.sklearn.log_model(  # type: ignore
-        sk_model=model,
-        name=model_name,
-        signature=signature,
-        registered_model_name=model_name,
+    Returns:
+        tuple: (model, features, model_version)
+    """
+    # Try to get the model by alias, otherwise use latest
+    try:
+        model_version_info = client.get_model_version_by_alias(
+            name=model_name,
+            alias=model_alias,
+        )
+        model_version = model_version_info.version
+        logger.info(f'Loaded model {model_name} with alias "{model_alias}" (version {model_version})')
+    except Exception as e:
+        logger.warning(f'No model found with alias {model_alias} for {model_name}. Using latest. {e}')
+        model_version = 'latest'
+
+    # Load the model and get its features
+    model_uri = f'models:/{model_name}/{model_version}'
+    model = mlflow.sklearn.load_model(model_uri)  # type: ignore
+
+    # Get features from model signature
+    model_info = mlflow.models.get_model_info(model_uri)  # type: ignore
+    features = model_info.signature.inputs.input_names()
+
+    return model, features, str(model_version)  # type: ignore
+
+def get_champion_model_mae(
+    model_name: str,
+    alias: str,
+) -> Optional[float]:
+    """
+    Get the champion model from the MLFlow model registry.
+    Returns None if no champion model exists yet.
+    """
+    try:
+        champion_model = client.get_model_version_by_alias(
+            name=model_name,
+            alias=alias,
+        )
+    except Exception as e:
+        logger.warning(f'No champion model found for {model_name}. {e}')
+        return None
+
+    champion_model_mae = client.get_metric_history(
+        run_id=champion_model.run_id,  # type: ignore
+        key='mean_absolute_error',
     )
-    logger.info(f'Model {model_name} pushed to the model registry')
+
+    return champion_model_mae[-1].value
+
+def validate_and_push_model_to_registry(
+    model_info: Any,  # MLflow model info object
+    X_test: pd.DataFrame,
+    y_test: pd.Series,
+    test_mae_baseline: float,
+    max_percent_diff_wrt_baseline: float,
+    model_name: str,
+    pair: str,
+) -> None:
+    """
+    Validate the model and update the champion model if it performs better.
+
+    Args:
+        model_info: MLflow model info object
+        X_test: Test features
+        y_test: Test target
+        test_mae_baseline: Baseline model MAE
+        max_percent_diff_wrt_baseline: Maximum allowed percentage difference from baseline
+        model_name: Name of the model
+        pair: Trading pair
+
+    Returns:
+        None
+    """
+
+    # Evaluate the model and generate model metrics
+    result = mlflow.evaluate(
+        model=model_info.model_uri,
+        # Combine X_test and y_test into a single DataFrame because the
+        # function expects a single DataFrame with a target column.
+        data=pd.concat([X_test, y_test], axis=1),
+        targets='target',
+        model_type='regressor',
+        evaluators='default',
+        evaluator_config={
+            'default': {}
+        },
+    )
+
+    try:
+        mlflow.validate_evaluation_results(
+            candidate_result=result,
+            validation_thresholds={
+                'mean_absolute_error': MetricThreshold(
+                    # The threshold is the maximum percentage difference
+                    # between the model's MAE and the baseline MAE.
+                    # We add 1 because the metric is a percentage difference
+                    # and we want to allow for a 10% difference.
+                    threshold=(1 + max_percent_diff_wrt_baseline) * test_mae_baseline,
+                    greater_is_better=False,
+                ),
+            }
+        )
+        is_model_passing_validation = True
+
+    except mlflow.exceptions.MlflowException as e:
+        logger.error(f'Model validation failed: {e}')
+        is_model_passing_validation = False
+
+    mlflow.set_tags({'passed_validation': str(is_model_passing_validation)})
+
+    new_model_mae = result.metrics["mean_absolute_error"]
+
+    # Log the model validation results
+    logger.info(f"Model {model_name} for {pair} validation: {'PASSED' if is_model_passing_validation else 'FAILED'} (MAE: {new_model_mae:.4f} vs baseline: {test_mae_baseline:.4f})")
+
+    # If the model scores better than the best model, update the best model
+    champion_model_mae = get_champion_model_mae(
+        model_name=model_name,
+        alias='champion',
+    )
+
+    # If no champion model exists yet, or if the new model is better, update the champion
+    if champion_model_mae is None or new_model_mae < champion_model_mae:
+        logger.info(f'Updating the champion model to {model_name}')
+        mv = client.create_model_version(
+            name=model_name,
+            source=model_info.model_uri,
+            run_id=model_info.run_id,
+        )
+
+        client.set_registered_model_alias(
+            name=model_name,
+            alias='champion',
+            version=mv.version,
+        )
+
+        logger.info(f'Successfully set alias "champion" for model {model_name} version {mv.version}')
+
+        if champion_model_mae is None:
+            logger.info(f"Set first champion model: {model_name} version {mv.version} (MAE: {new_model_mae:.4f})")
+        else:
+            improvement = (champion_model_mae / new_model_mae - 1) * 100
+            logger.info(f"Updated champion model: {model_name} version {mv.version} (MAE: {new_model_mae:.4f} vs {champion_model_mae:.4f}, {improvement:.2f}% improvement)")
+
+    else:
+        logger.info(f'{model_name} is not better than the current champion (MAE: {new_model_mae:.4f} >= {champion_model_mae:.4f})')

--- a/services/predictor/src/predictor/model_registry.py
+++ b/services/predictor/src/predictor/model_registry.py
@@ -22,6 +22,15 @@ from mlflow.tracking import MlflowClient
 
 client = MlflowClient()
 
+# TODO: Replace model name with something generic like `cryptocurrency-model`
+# and handle the other naming parameters via MLFlow tags. See documentation:
+# https://www.mlflow.org/docs/latest/ml/model-registry/
+# We can potentially use the tags to store other data such as:
+# - Pair
+# - Candle seconds
+# - Prediction horizon seconds
+# - Validation passed/failed
+
 def get_model_name(
     pair: str,
     candle_seconds: int,

--- a/services/predictor/src/predictor/models.py
+++ b/services/predictor/src/predictor/models.py
@@ -580,9 +580,10 @@ def get_model_candidates(
 
     # fit N models with default hyperparameters
     reg = LazyRegressor(
-        verbose=0,
-        ignore_warnings=False,
+        verbose=1,  # Show progress
+        ignore_warnings=True,  # Ignore warnings to prevent crashes
         custom_metric=mean_absolute_error,
+        predictions=True,  # Return predictions for efficiency
     )
     models, _ = reg.fit(X_train, X_test, y_train, y_test)
 

--- a/services/predictor/src/predictor/predict.py
+++ b/services/predictor/src/predictor/predict.py
@@ -1,0 +1,180 @@
+"""
+Predictor service for real-time cryptocurrency price prediction.
+
+This module provides functionality to load trained models from MLflow and generate
+real-time predictions based on incoming technical indicator data from RisingWave.
+
+The predictor continuously monitors the input table for new data and generates
+predictions that are written to an output table, enabling real-time trading
+signals and market analysis.
+
+Key Features:
+- Model loading from MLflow registry with version control
+- Real-time data streaming from RisingWave
+- Automated prediction generation on new data
+- Configurable prediction horizons and trading pairs
+- Integration with technical indicator pipelines
+
+Example:
+    The predictor can be configured to monitor cryptocurrency trading pairs data with
+    a given candle size and generate predictions for a given prediction horizon,
+    writing results to a predictions table for downstream trading systems or analysis
+    dashboards.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+from loguru import logger
+from risingwave import (
+    OutputFormat,
+    RisingWave,
+    RisingWaveConnOptions,
+)
+
+from predictor.config import predictor_config
+from predictor.model_registry import (
+    get_model_name,
+    load_model,
+)
+
+
+def predict(
+    mlflow_tracking_uri: str,
+    model_version: str,
+    pair: str,
+    candle_seconds: int,
+    prediction_horizon_seconds: int,
+    risingwave_host: str,
+    risingwave_port: int,
+    risingwave_user: str,
+    risingwave_password: str,
+    risingwave_database: str,
+    risingwave_schema: str,
+    risingwave_input_table: str,
+    risingwave_output_table: str,
+):
+    """
+    Generates a new prediction as soon as new data is available in the `risingwave_input_table`.
+
+    Steps:
+    1. Load the model from the MLFlow registry with the given `model_version` if provided. Otherwise, use the latest model.
+    2. Start listening to the `risingwave_input_table` for new data.
+    3. For each new or updated row, generate a new prediction.
+    4. Write the prediction to the `risingwave_output_table`.
+
+    Args:
+        mlflow_tracking_uri: The URI of the MLFlow tracking server.
+        model_version: The version of the model to use for prediction.
+        pair: The pair to predict.
+        candle_seconds: The number of seconds in a candle.
+        prediction_horizon_seconds: The number of seconds to predict.
+        risingwave_host: The host of the RisingWave instance.
+        risingwave_port: The port of the RisingWave instance.
+        risingwave_user: The user of the RisingWave instance.
+        risingwave_password: The password of the RisingWave instance.
+        risingwave_database: The database of the RisingWave instance.
+        risingwave_schema: The schema of the RisingWave instance.
+        risingwave_input_table: The input table of the RisingWave instance.
+        risingwave_output_table: The output table of the RisingWave instance.
+    """
+    # Step 1: Load the model from the MLFlow registry with the given `model_version` if provided. Otherwise, use the latest model.
+    model_name = get_model_name(pair, candle_seconds, prediction_horizon_seconds)
+    model, features, model_version = load_model(model_name, model_version)
+    logger.info(f'Loaded model: {model_name} with features: {features}')
+
+    # Step 2: Start listening to the `risingwave_input_table` for new data.
+    rw = RisingWave(
+        RisingWaveConnOptions.from_connection_info(
+            host=risingwave_host,
+            port=risingwave_port,
+            user=risingwave_user,
+            password=risingwave_password,
+            database=risingwave_database,
+        )
+    )
+
+    def prediction_handler(data: pd.DataFrame) -> Any:
+        """
+        Maps the data changes to fresh predictions using the loaded model. These
+        predictions are then written to the `risingwave_output_table`.
+        """
+        logger.info('Reading new data...')
+
+        # We only read Insert and Updates.
+        data = data[data['op'].isin(['Insert', 'UpdateInsert'])] # type: ignore
+
+        # Keep only the data for the given pair.
+        data = data[data['pair'] == pair] # type: ignore
+
+        # Keep only the relevant features.
+        data = data[features] # type: ignore
+
+        # We only read recent data.
+        ts_ms = int(datetime.now(timezone.utc).timestamp() * 1000)  # current time in milliseconds UTC
+        data = data[
+            data['window_start_ms'] > (ts_ms - 1000 * candle_seconds * 5)
+        ]  # type: ignore
+
+        if data.empty:
+            logger.info('No data to predict')
+            return
+
+        logger.info(f'Received new data: {data.shape[0]} row/s updated')
+        logger.info(f'Data:\n {data.head(5)}')
+
+        # Step 3: For each new or updated row, generate a new prediction.
+        predictions: pd.Series = model.predict(data) # type: ignore
+
+        # Write the predictions to the `risingwave_output_table`.
+        # Update ts_ms to the current time.
+        ts_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+
+        predicted_ts_ms = (
+            data['window_start_ms'] + (candle_seconds + prediction_horizon_seconds) * 1000 # predicted time in milliseconds UTC
+        ).to_list()
+
+        output = pd.DataFrame({
+            'pair': pair,
+            'ts_ms': ts_ms,
+            'model_name': model_name,
+            'model_version': model_version,
+            'predicted_ts_ms': predicted_ts_ms,
+            'predicted_price': predictions,
+        })
+
+        # Step 4: Write the prediction to the `risingwave_schema.risingwave_output_table`.
+        logger.info(f'Writing predictions to {risingwave_schema}.{risingwave_output_table}')
+        logger.info(f'Output:\n {output.head(5)}')
+        rw.insert(
+            table_name=risingwave_output_table,
+            schema_name=risingwave_schema,
+            data=output,
+        )
+        logger.info(f'{data.shape[0]} row/s written to {risingwave_schema}.{risingwave_output_table} successfully.')
+
+    rw.on_change(
+        subscribe_from=risingwave_input_table,
+        schema_name=risingwave_schema,
+        handler=prediction_handler,
+        output_format=OutputFormat.DATAFRAME,
+    )
+
+
+if __name__ == '__main__':
+    predict(
+        mlflow_tracking_uri=predictor_config.mlflow_tracking_uri,
+        model_version=predictor_config.model_version,
+        pair=predictor_config.pair,
+        candle_seconds=predictor_config.candle_seconds,
+        prediction_horizon_seconds=predictor_config.prediction_horizon_seconds,
+        risingwave_host=predictor_config.risingwave_host,
+        risingwave_port=predictor_config.risingwave_port,
+        risingwave_user=predictor_config.risingwave_user,
+        risingwave_password=predictor_config.risingwave_password,
+        risingwave_database=predictor_config.risingwave_database,
+        risingwave_schema=predictor_config.risingwave_schema,
+        risingwave_input_table=predictor_config.risingwave_input_table,
+        risingwave_output_table=predictor_config.risingwave_output_table,
+    )

--- a/services/predictor/src/predictor/predict.py
+++ b/services/predictor/src/predictor/predict.py
@@ -42,7 +42,6 @@ from predictor.model_registry import (
 
 def predict(
     mlflow_tracking_uri: str,
-    model_version: str,
     pair: str,
     candle_seconds: int,
     prediction_horizon_seconds: int,
@@ -54,19 +53,19 @@ def predict(
     risingwave_schema: str,
     risingwave_input_table: str,
     risingwave_output_table: str,
+    model_alias: str = 'champion',
 ):
     """
     Generates a new prediction as soon as new data is available in the `risingwave_input_table`.
 
     Steps:
-    1. Load the model from the MLFlow registry with the given `model_version` if provided. Otherwise, use the latest model.
+    1. Load the model from the MLFlow registry with the given `model_alias` if provided. Otherwise, use the latest model.
     2. Start listening to the `risingwave_input_table` for new data.
     3. For each new or updated row, generate a new prediction.
     4. Write the prediction to the `risingwave_output_table`.
 
     Args:
         mlflow_tracking_uri: The URI of the MLFlow tracking server.
-        model_version: The version of the model to use for prediction.
         pair: The pair to predict.
         candle_seconds: The number of seconds in a candle.
         prediction_horizon_seconds: The number of seconds to predict.
@@ -78,10 +77,11 @@ def predict(
         risingwave_schema: The schema of the RisingWave instance.
         risingwave_input_table: The input table of the RisingWave instance.
         risingwave_output_table: The output table of the RisingWave instance.
+        model_alias: The alias of the model to use for prediction.
     """
-    # Step 1: Load the model from the MLFlow registry with the given `model_version` if provided. Otherwise, use the latest model.
+    # Step 1: Load the model from the MLFlow registry with the given `model_alias` if provided. Otherwise, use the latest model.
     model_name = get_model_name(pair, candle_seconds, prediction_horizon_seconds)
-    model, features, model_version = load_model(model_name, model_version)
+    model, features, model_version = load_model(model_name, model_alias)
     logger.info(f'Loaded model: {model_name} with features: {features}')
 
     # Step 2: Start listening to the `risingwave_input_table` for new data.
@@ -165,7 +165,6 @@ def predict(
 if __name__ == '__main__':
     predict(
         mlflow_tracking_uri=predictor_config.mlflow_tracking_uri,
-        model_version=predictor_config.model_version,
         pair=predictor_config.pair,
         candle_seconds=predictor_config.candle_seconds,
         prediction_horizon_seconds=predictor_config.prediction_horizon_seconds,
@@ -177,4 +176,5 @@ if __name__ == '__main__':
         risingwave_schema=predictor_config.risingwave_schema,
         risingwave_input_table=predictor_config.risingwave_input_table,
         risingwave_output_table=predictor_config.risingwave_output_table,
+        model_alias=predictor_config.model_alias,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1957,6 +1957,7 @@ version = "0.1.0"
 source = { editable = "services/predictor" }
 dependencies = [
     { name = "loguru" },
+    { name = "matplotlib" },
     { name = "mlflow" },
     { name = "numpy" },
     { name = "optuna" },
@@ -1964,6 +1965,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "risingwave-py" },
     { name = "scikit-learn" },
+    { name = "shap" },
 ]
 
 [package.optional-dependencies]
@@ -1991,6 +1993,7 @@ requires-dist = [
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "lazypredict", marker = "extra == 'training'", specifier = ">=0.2.16" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "mlflow", specifier = ">=3.1.1" },
     { name = "notebook", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "numpy", specifier = ">=1.26.0" },
@@ -2000,6 +2003,7 @@ requires-dist = [
     { name = "risingwave-py", specifier = ">=0.0.2" },
     { name = "scikit-learn", specifier = ">=1.7.0" },
     { name = "setuptools", marker = "extra == 'training'", specifier = ">=69.0.0" },
+    { name = "shap", specifier = ">=0.48.0" },
     { name = "ydata-profiling", marker = "extra == 'training'", specifier = ">=4.16.1" },
 ]
 provides-extras = ["training", "dev"]
@@ -2645,12 +2649,47 @@ wheels = [
 ]
 
 [[package]]
+name = "shap"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "slicer" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/79/edeb71f5ee8a936a1d40413188000640ab91da72771e837f1ded141a0ed4/shap-0.48.0.tar.gz", hash = "sha256:f169dc73fe144e70a0331b5507f9fd290d7695a3c7935fa8e4862e376321baf9", size = 3061913, upload-time = "2025-06-12T13:05:35.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a8/4808d83e9f665de79019b8b220182e0a2e9a02b47554a649ebc2205e0964/shap-0.48.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7277690f2240ccbdd0725f1f654f7ecb09944c330122e7464a83a24e337ddbd6", size = 556643, upload-time = "2025-06-12T13:05:07.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/7b/78385eb2a1c8bdfbc099f6cada581a286d93a36bcd496f22c0d33bc6536e/shap-0.48.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ee94e7a429ba4ab3c645da4c2ad9dd78d26889a9fbe75a7e3a744f320ae4de4", size = 547637, upload-time = "2025-06-12T13:05:09.254Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/3a/0505be445de822bc69c491741bbaf304e0ec0795dc13165b6b740a3e152d/shap-0.48.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0d0cc355d4f5091b32827c8fa425378ac76f50a4e2891e026ce5cc5c0d7a036", size = 1017867, upload-time = "2025-06-12T13:05:10.866Z" },
+    { url = "https://files.pythonhosted.org/packages/96/37/05eb3ce6c31b20c84a124116742363de1f32ff4156432888aed1e3135b22/shap-0.48.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9aebc7f7c348eae07cb3a970e030487362712ff1d4efd8941656b508a9bfbcc7", size = 1023440, upload-time = "2025-06-12T13:05:12.198Z" },
+    { url = "https://files.pythonhosted.org/packages/46/30/01f17399a42c7baa2589dd27aadd278fd43cee50957dd6b102e504776e1e/shap-0.48.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:14ddf529a628902b93c19e59431c5054b8c7be55d7b9d6c6064763b2275e1e56", size = 2085897, upload-time = "2025-06-12T13:05:14.201Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/34/3dd677ef2a98b74c95188a3fc248cfcb81670a1410ef388f063c962616fa/shap-0.48.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea19d7e8eb0071e4f734bca67c12efe8e3b1ef5418915265f0cb9f720ad8d08e", size = 545341, upload-time = "2025-06-12T13:05:15.709Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slicer"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/f9/b4bce2825b39b57760b361e6131a3dacee3d8951c58cb97ad120abb90317/slicer-0.0.8.tar.gz", hash = "sha256:2e7553af73f0c0c2d355f4afcc3ecf97c6f2156fcf4593955c3f56cf6c4d6eb7", size = 14894, upload-time = "2024-03-09T23:35:26.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/81/9ef641ff4e12cbcca30e54e72fb0951a2ba195d0cda0ba4100e532d929db/slicer-0.0.8-py3-none-any.whl", hash = "sha256:6c206258543aecd010d497dc2eca9d2805860a0b3758673903456b7df7934dc3", size = 15251, upload-time = "2024-03-09T07:03:07.708Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -438,6 +438,11 @@ talib = [
     { name = "ta-lib" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "candles", editable = "services/candles" },
@@ -453,6 +458,9 @@ requires-dist = [
     { name = "websocket-client", specifier = ">=1.8.0" },
 ]
 provides-extras = ["talib"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.12.1" }]
 
 [[package]]
 name = "cryptography"
@@ -1971,6 +1979,11 @@ training = [
     { name = "ydata-profiling" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "great-expectations", marker = "extra == 'training'", specifier = ">=0.18.0" },
@@ -1990,6 +2003,9 @@ requires-dist = [
     { name = "ydata-profiling", marker = "extra == 'training'", specifier = ">=4.16.1" },
 ]
 provides-extras = ["training", "dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.12.1" }]
 
 [[package]]
 name = "prometheus-client"
@@ -2521,6 +2537,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/db/5d/36619b61ffa2429eeaefaab4f3374666adf36ad8ac6330d855848d7d36fd/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d", size = 715692, upload-time = "2024-12-11T19:58:17.252Z" },
     { url = "https://files.pythonhosted.org/packages/b1/82/85cb92f15a4231c89b95dfe08b09eb6adca929ef7df7e17ab59902b6f589/ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5", size = 98777, upload-time = "2024-10-20T10:13:01.395Z" },
     { url = "https://files.pythonhosted.org/packages/d7/8f/c3654f6f1ddb75daf3922c3d8fc6005b1ab56671ad56ffb874d908bfa668/ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4", size = 115523, upload-time = "2024-10-20T10:13:02.768Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/38/796a101608a90494440856ccfb52b1edae90de0b817e76bfade66b12d320/ruff-0.12.1.tar.gz", hash = "sha256:806bbc17f1104fd57451a98a58df35388ee3ab422e029e8f5cf30aa4af2c138c", size = 4413426, upload-time = "2025-06-26T20:34:14.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/bf/3dba52c1d12ab5e78d75bd78ad52fb85a6a1f29cc447c2423037b82bed0d/ruff-0.12.1-py3-none-linux_armv6l.whl", hash = "sha256:6013a46d865111e2edb71ad692fbb8262e6c172587a57c0669332a449384a36b", size = 10305649, upload-time = "2025-06-26T20:33:39.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/65/dab1ba90269bc8c81ce1d499a6517e28fe6f87b2119ec449257d0983cceb/ruff-0.12.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b3f75a19e03a4b0757d1412edb7f27cffb0c700365e9d6b60bc1b68d35bc89e0", size = 11120201, upload-time = "2025-06-26T20:33:42.207Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/3e/2d819ffda01defe857fa2dd4cba4d19109713df4034cc36f06bbf582d62a/ruff-0.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9a256522893cb7e92bb1e1153283927f842dea2e48619c803243dccc8437b8be", size = 10466769, upload-time = "2025-06-26T20:33:44.102Z" },
+    { url = "https://files.pythonhosted.org/packages/63/37/bde4cf84dbd7821c8de56ec4ccc2816bce8125684f7b9e22fe4ad92364de/ruff-0.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:069052605fe74c765a5b4272eb89880e0ff7a31e6c0dbf8767203c1fbd31c7ff", size = 10660902, upload-time = "2025-06-26T20:33:45.98Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3a/390782a9ed1358c95e78ccc745eed1a9d657a537e5c4c4812fce06c8d1a0/ruff-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a684f125a4fec2d5a6501a466be3841113ba6847827be4573fddf8308b83477d", size = 10167002, upload-time = "2025-06-26T20:33:47.81Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/05/f2d4c965009634830e97ffe733201ec59e4addc5b1c0efa035645baa9e5f/ruff-0.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdecdef753bf1e95797593007569d8e1697a54fca843d78f6862f7dc279e23bd", size = 11751522, upload-time = "2025-06-26T20:33:49.857Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4e/4bfc519b5fcd462233f82fc20ef8b1e5ecce476c283b355af92c0935d5d9/ruff-0.12.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:70d52a058c0e7b88b602f575d23596e89bd7d8196437a4148381a3f73fcd5010", size = 12520264, upload-time = "2025-06-26T20:33:52.199Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/7756a6925da236b3a31f234b4167397c3e5f91edb861028a631546bad719/ruff-0.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84d0a69d1e8d716dfeab22d8d5e7c786b73f2106429a933cee51d7b09f861d4e", size = 12133882, upload-time = "2025-06-26T20:33:54.231Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/00/40da9c66d4a4d51291e619be6757fa65c91b92456ff4f01101593f3a1170/ruff-0.12.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6cc32e863adcf9e71690248607ccdf25252eeeab5193768e6873b901fd441fed", size = 11608941, upload-time = "2025-06-26T20:33:56.202Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e7/f898391cc026a77fbe68dfea5940f8213622474cb848eb30215538a2dadf/ruff-0.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fd49a4619f90d5afc65cf42e07b6ae98bb454fd5029d03b306bd9e2273d44cc", size = 11602887, upload-time = "2025-06-26T20:33:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/02/0891872fc6aab8678084f4cf8826f85c5d2d24aa9114092139a38123f94b/ruff-0.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ed5af6aaaea20710e77698e2055b9ff9b3494891e1b24d26c07055459bb717e9", size = 10521742, upload-time = "2025-06-26T20:34:00.465Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/98/d6534322c74a7d47b0f33b036b2498ccac99d8d8c40edadb552c038cecf1/ruff-0.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:801d626de15e6bf988fbe7ce59b303a914ff9c616d5866f8c79eb5012720ae13", size = 10149909, upload-time = "2025-06-26T20:34:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5c/9b7ba8c19a31e2b6bd5e31aa1e65b533208a30512f118805371dbbbdf6a9/ruff-0.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2be9d32a147f98a1972c1e4df9a6956d612ca5f5578536814372113d09a27a6c", size = 11136005, upload-time = "2025-06-26T20:34:04.723Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/34/9bbefa4d0ff2c000e4e533f591499f6b834346025e11da97f4ded21cb23e/ruff-0.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49b7ce354eed2a322fbaea80168c902de9504e6e174fd501e9447cad0232f9e6", size = 11648579, upload-time = "2025-06-26T20:34:06.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1c/20cdb593783f8f411839ce749ec9ae9e4298c2b2079b40295c3e6e2089e1/ruff-0.12.1-py3-none-win32.whl", hash = "sha256:d973fa626d4c8267848755bd0414211a456e99e125dcab147f24daa9e991a245", size = 10519495, upload-time = "2025-06-26T20:34:08.718Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/56/7158bd8d3cf16394928f47c637d39a7d532268cd45220bdb6cd622985760/ruff-0.12.1-py3-none-win_amd64.whl", hash = "sha256:9e1123b1c033f77bd2590e4c1fe7e8ea72ef990a85d2484351d408224d603013", size = 11547485, upload-time = "2025-06-26T20:34:11.008Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d0/6902c0d017259439d6fd2fd9393cea1cfe30169940118b007d5e0ea7e954/ruff-0.12.1-py3-none-win_arm64.whl", hash = "sha256:78ad09a022c64c13cc6077707f036bab0fac8cd7088772dcd1e5be21c5002efc", size = 10691209, upload-time = "2025-06-26T20:34:12.928Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
#### Created and deployed a `prediction-generator` that does the following:

1. Takes `pair`, `candle_seconds`, and `prediction_horizon_seconds` as input
2. Loads the model from the MLFlow model registry with the alias `champion`
3. Reads data from the `technical_indicators` RisingWave table based on the input parameters
4. Predicts the price for the next `prediction_horizon_seconds`
5. Writes the predictions to the `predictions` RisingWave table
6. Deploy this on kubernetes

#### Added automatic model validation and selection:

1. Tag the best model with the alias `champion`
2. If the current model outperforms the champion, it will be set as the new champion
3. Use the champion model instead of the latest version for the `prediction-generator` service

#### TODO:
Organize the model registry so that we rely on tags instead of handling all
the parameters in the model name. See #TODO in `model_registry.py` for more details.